### PR TITLE
[WIP] Bitwise operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+.idea/

--- a/src/__tests__/bitwise-operators-spec.js
+++ b/src/__tests__/bitwise-operators-spec.js
@@ -39,3 +39,18 @@ test("chain bitwise xor operator", t => {
   `).then(outputIs(t, 1));
 });
 
+test("chain bitwise and operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 15 & 7 & 2;
+    }
+  `).then(outputIs(t, 2));
+});
+
+test("chain bitwise or operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 8 | 4 | 2 | 1;
+    }
+  `).then(outputIs(t, 15));
+});

--- a/src/__tests__/bitwise-operators-spec.js
+++ b/src/__tests__/bitwise-operators-spec.js
@@ -1,0 +1,41 @@
+import test from "ava";
+import compile from "..";
+
+const compileAndRun = (src, importsObj = {}) =>
+  WebAssembly.instantiate(compile(src), importsObj);
+
+const outputIs = (t, value) => result =>
+  t.is(result.instance.exports.test(), value);
+
+test("bitwise and operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 1 & 1;
+    }
+  `).then(outputIs(t, 1));
+});
+
+test("bitwise or operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 0 | 0;
+    }
+  `).then(outputIs(t, 0));
+});
+
+test("bitwise xor operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 1 ^ 1;
+    }
+  `).then(outputIs(t, 0));
+});
+
+test("chain bitwise xor operator", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 1 ^ 1 ^ 1;
+    }
+  `).then(outputIs(t, 1));
+});
+

--- a/src/__tests__/operator-precedence-spec.js
+++ b/src/__tests__/operator-precedence-spec.js
@@ -23,7 +23,6 @@ test("test correct precedence", t => {
   `).then(outputIs(t, 6));
 });
 
-
 test("test correct precedence with negative numbers", t => {
   compileAndRun(`
     export function test(): i32 {

--- a/src/__tests__/operator-precedence-spec.js
+++ b/src/__tests__/operator-precedence-spec.js
@@ -1,0 +1,41 @@
+import test from "ava";
+import compile from "..";
+
+const compileAndRun = (src, importsObj = {}) =>
+  WebAssembly.instantiate(compile(src), importsObj);
+
+const outputIs = (t, value) => result =>
+  t.is(result.instance.exports.test(), value);
+
+test("test correct precedence", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 8 - 3 * 7 | 3 * 9 * 6 + 6 * 10;
+    }
+  `).then(outputIs(t, -1));
+});
+
+test("test correct precedence", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 9 - 3 ^ 10 + 6 & 1 & 6 & 6 & 10 - 9;
+    }
+  `).then(outputIs(t, 6));
+});
+
+
+test("test correct precedence with negative numbers", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return 4 * -3 * -1 + 9 - 2 | 8 * 8 & -6 ^ 3;
+    }
+  `).then(outputIs(t, 83));
+});
+
+test("test correct precedence with parenthesis", t => {
+  compileAndRun(`
+    export function test(): i32 {
+      return (1 + 1) ^ (3 * 3);
+    }
+  `).then(outputIs(t, 11));
+});

--- a/src/emitter/opcode.js
+++ b/src/emitter/opcode.js
@@ -289,6 +289,12 @@ export const opcodeFromOperator = ({
       return def.Else;
     case "[":
       return def[type + "Load"];
+    case "&":
+      return def[type + "And"];
+    case "|":
+      return def[type + "Or"];
+    case "^":
+      return def[type + "Xor"];
     default:
       throw new Error(`No mapping from operator to opcode ${value}`);
   }

--- a/src/parser/patch-typecasts.js
+++ b/src/parser/patch-typecasts.js
@@ -19,6 +19,9 @@ export const isBinaryMathExpression = (node: NodeType): boolean => {
     case ">=":
     case "<=":
     case "!=":
+    case "&":
+    case "|":
+    case "^":
       return true;
     default:
       return false;

--- a/src/parser/precedence.js
+++ b/src/parser/precedence.js
@@ -36,6 +36,6 @@ const precedence = {
   ":": PRECEDENCE_KEY_VALUE_PAIR,
   "^": PRECEDENCE_BITWISE_XOR,
   "&": PRECEDENCE_BITWISE_AND,
-  "|": PRECEDENCE_BITWISE_OR
+  "|": PRECEDENCE_BITWISE_OR,
 };
 export default precedence;

--- a/src/parser/precedence.js
+++ b/src/parser/precedence.js
@@ -11,9 +11,9 @@ export const PRECEDENCE_DIVIDE = 1;
 export const PRECEDENCE_INCREMENT = 2;
 export const PRECEDENCE_DECREMENT = 2;
 export const PRECEDENCE_ASSIGNMENT = 3;
-export const PRECEDENCE_BITWISE_OR = 7;
-export const PRECEDENCE_BITWISE_XOR = 8;
-export const PRECEDENCE_BITWISE_AND = 9;
+export const PRECEDENCE_BITWISE_OR = -3;
+export const PRECEDENCE_BITWISE_XOR = -2;
+export const PRECEDENCE_BITWISE_AND = -1;
 
 export const PRECEDENCE_FUNCTION_CALL = 19;
 export const PRECEDENCE_KEY_VALUE_PAIR = -1;

--- a/src/parser/precedence.js
+++ b/src/parser/precedence.js
@@ -11,6 +11,9 @@ export const PRECEDENCE_DIVIDE = 1;
 export const PRECEDENCE_INCREMENT = 2;
 export const PRECEDENCE_DECREMENT = 2;
 export const PRECEDENCE_ASSIGNMENT = 3;
+export const PRECEDENCE_BITWISE_OR = 7;
+export const PRECEDENCE_BITWISE_XOR = 8;
+export const PRECEDENCE_BITWISE_AND = 9;
 
 export const PRECEDENCE_FUNCTION_CALL = 19;
 export const PRECEDENCE_KEY_VALUE_PAIR = -1;
@@ -31,5 +34,8 @@ const precedence = {
   ">": 5,
   "<": 5,
   ":": PRECEDENCE_KEY_VALUE_PAIR,
+  "^": PRECEDENCE_BITWISE_XOR,
+  "&": PRECEDENCE_BITWISE_AND,
+  "|": PRECEDENCE_BITWISE_OR
 };
 export default precedence;


### PR DESCRIPTION
Started working on issue #33. 

As said in the issue the change looks as easy as adding to the `opcode.js` file. While writing a few tests I discovered that chaining binary operators does not work. I get the following error after running `"chain bitwise xor operator"` test in `bitwise-operators-spec.js`:
```
Invariant Violation (Error) {
    framesToPop: 1,
    message: `Unknown opcode generated in block index 2 {}. ␊
    Operand: ␊
    BinaryExpression ^ ␊
      Constant<i32> 1 ␊
      Constant<i32> 1 ␊
    `,
  }
```

Any help is appreciated while I try to track down the issue.
