### PR TITLE
Use setTimeout fully qualified name to clarify intention

### DIFF
--- a/packages/walt-docs/src/examples/function-pointer.js
+++ b/packages/walt-docs/src/examples/function-pointer.js
@@ -15,7 +15,7 @@ function compile(buffer) {
         const func = table.get(functionPointer);
         console.log("Getting function from Table", table);
         console.log(`function pointer id: ${functionPointer} == ${func}`);
-        setTimeout(func, timeout);
+        window.setTimeout(func, timeout);
       }
     }
   }).then(result => result.instance.exports.test());


### PR DESCRIPTION
The function pointer example caused some confusion for me because the setTimeout function is shadowed by one of the env properties. This PR explicitly qualifies setTimeout (i.e. `window.setTimeout`) to fix the name shadowing confusion.