### PR TITLE
fix parse api typo in compiler readmer

### DIFF
--- a/packages/walt-compiler/README.md
+++ b/packages/walt-compiler/README.md
@@ -29,9 +29,9 @@ type information. This tree cannot be directly compiled without semantic analysi
 can be transformed easily.
 
 ```js
-import { parse } from 'walt-compiler';
+import { parser } from 'walt-compiler';
 
-const ast = parse(`
+const ast = parser(`
   type MyObjectType = { 'foo': i32, 'bar': f32 };
   export function test(): f32 {
     const obj: MyObjectType = 0;


### PR DESCRIPTION
This PR fixes a typo in the readme. The exported function is called `parser`. 