### PR TITLE
Initial submission to provide Production build support for Walt-explorer

### DIFF
--- a/packages/walt-docs/package-lock.json
+++ b/packages/walt-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "walt-docs",
-	"version": "1.1.6",
+	"version": "1.1.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -16,7 +16,7 @@
 			"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
 			"dev": true,
 			"requires": {
-				"mime-types": "~2.1.16",
+				"mime-types": "2.1.17",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -32,7 +32,7 @@
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
 			"dev": true,
 			"requires": {
-				"acorn": "^4.0.3"
+				"acorn": "4.0.13"
 			},
 			"dependencies": {
 				"acorn": {
@@ -49,7 +49,7 @@
 			"integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.3"
+				"acorn": "5.1.2"
 			}
 		},
 		"ajv": {
@@ -58,16 +58,16 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-			"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
 			"dev": true
 		},
 		"align-text": {
@@ -76,9 +76,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"alphanum-sort": {
@@ -123,15 +123,14 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
@@ -139,8 +138,8 @@
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"argparse": {
@@ -149,7 +148,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -158,13 +157,19 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1"
+				"arr-flatten": "1.1.0"
 			}
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
 		"array-find-index": {
@@ -185,8 +190,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.8.2"
 			}
 		},
 		"array-union": {
@@ -195,7 +200,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -227,18 +232,18 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"asn1.js": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"assert": {
@@ -248,6 +253,23 @@
 			"dev": true,
 			"requires": {
 				"util": "0.10.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
+				},
+				"util": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.1"
+					}
+				}
 			}
 		},
 		"assert-plus": {
@@ -256,13 +278,19 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.14.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"async-each": {
@@ -283,18 +311,24 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
 		"autoprefixer": {
 			"version": "6.7.7",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
 			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
 			"dev": true,
 			"requires": {
-				"browserslist": "^1.7.6",
-				"caniuse-db": "^1.0.30000634",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^5.2.16",
-				"postcss-value-parser": "^3.2.3"
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000733",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -303,8 +337,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000733",
+						"electron-to-chromium": "1.3.21"
 					}
 				}
 			}
@@ -327,9 +361,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -338,25 +372,25 @@
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"debug": "^2.6.8",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.7",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.0",
+				"debug": "2.6.8",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.7",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -365,14 +399,14 @@
 			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.6",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -381,9 +415,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -392,9 +426,9 @@
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -403,10 +437,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -415,10 +449,10 @@
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -427,9 +461,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -438,11 +472,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -451,8 +485,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -461,8 +495,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -471,8 +505,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -481,9 +515,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -492,11 +526,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -505,12 +539,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -519,8 +553,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-loader": {
@@ -529,9 +563,9 @@
 			"integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1"
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -540,7 +574,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -549,7 +583,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -600,9 +634,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -611,10 +645,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -623,7 +657,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -632,7 +666,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -641,11 +675,11 @@
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -654,15 +688,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -671,8 +705,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -681,7 +715,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -690,8 +724,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -700,7 +734,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -709,9 +743,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -720,7 +754,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -729,9 +763,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -740,10 +774,10 @@
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -752,9 +786,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -763,9 +797,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -774,8 +808,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -784,12 +818,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -798,8 +832,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -808,7 +842,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -817,9 +851,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -828,7 +862,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -837,7 +871,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -846,9 +880,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -857,9 +891,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -868,8 +902,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -878,8 +912,8 @@
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -888,7 +922,7 @@
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -897,9 +931,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -908,8 +942,8 @@
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -918,8 +952,8 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -928,7 +962,7 @@
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -937,8 +971,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-env": {
@@ -947,36 +981,36 @@
 			"integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^2.1.2",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"browserslist": "2.4.0",
+				"invariant": "2.2.2",
+				"semver": "5.4.1"
 			}
 		},
 		"babel-preset-flow": {
@@ -985,7 +1019,7 @@
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
+				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
 		},
 		"babel-preset-react": {
@@ -994,12 +1028,12 @@
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-preset-flow": "6.23.0"
 			}
 		},
 		"babel-register": {
@@ -1008,13 +1042,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.1",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			}
 		},
 		"babel-runtime": {
@@ -1022,8 +1056,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.1",
+				"regenerator-runtime": "0.11.0"
 			}
 		},
 		"babel-template": {
@@ -1032,11 +1066,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1045,15 +1079,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.8",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-types": {
@@ -1062,10 +1096,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1077,13 +1111,73 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
 		},
 		"base64-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
 			"dev": true
 		},
 		"batch": {
@@ -1099,7 +1193,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"big.js": {
@@ -1120,8 +1214,13 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.3"
 			}
+		},
+		"bluebird": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -1135,21 +1234,20 @@
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 			"dev": true,
 			"requires": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^6.0.1",
-				"multicast-dns-service-types": "^1.1.0"
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.1.1",
+				"multicast-dns-service-types": "1.1.0"
 			}
 		},
 		"brace-expansion": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1159,9 +1257,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
 			}
 		},
 		"brorand": {
@@ -1171,39 +1269,48 @@
 			"dev": true
 		},
 		"browserify-aes": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-			"integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+			"version": "1.2.0",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"browserify-cipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
+				"browserify-aes": "1.2.0",
+				"browserify-des": "1.0.2",
+				"evp_bytestokey": "1.0.3"
 			}
 		},
 		"browserify-des": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1"
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"browserify-rsa": {
@@ -1212,8 +1319,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
 			}
 		},
 		"browserify-sign": {
@@ -1222,22 +1329,22 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"elliptic": "6.4.1",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.1"
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "~0.2.0"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -1246,8 +1353,8 @@
 			"integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000718",
-				"electron-to-chromium": "^1.3.18"
+				"caniuse-lite": "1.0.30000733",
+				"electron-to-chromium": "1.3.21"
 			}
 		},
 		"buffer": {
@@ -1256,10 +1363,15 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.12",
+				"isarray": "1.0.0"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -1291,13 +1403,57 @@
 			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
 			"dev": true
 		},
+		"cacache": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"requires": {
+				"bluebird": "3.5.2",
+				"chownr": "1.1.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.1",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.3.0",
+				"unique-filename": "1.1.1",
+				"y18n": "4.0.0"
+			},
+			"dependencies": {
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				}
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
+			}
+		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -1318,8 +1474,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			}
 		},
 		"caniuse-api": {
@@ -1328,10 +1484,10 @@
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"dev": true,
 			"requires": {
-				"browserslist": "^1.3.6",
-				"caniuse-db": "^1.0.30000529",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000733",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -1340,8 +1496,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000733",
+						"electron-to-chromium": "1.3.21"
 					}
 				}
 			}
@@ -1370,8 +1526,8 @@
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"dev": true,
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			},
 			"dependencies": {
 				"lazy-cache": {
@@ -1388,11 +1544,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chardet": {
@@ -1407,16 +1563,21 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.2",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
 			}
+		},
+		"chownr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -1424,8 +1585,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"circular-json": {
@@ -1440,7 +1601,30 @@
 			"integrity": "sha1-aD9vk6MgeU0Sk4bXSyodLWb+3n4=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3"
+				"chalk": "1.1.3"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				}
 			}
 		},
 		"classnames": {
@@ -1454,7 +1638,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -1469,9 +1653,9 @@
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
 			}
 		},
 		"clone": {
@@ -1486,10 +1670,10 @@
 			"integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
 			"dev": true,
 			"requires": {
-				"for-own": "^1.0.0",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.2.2",
-				"shallow-clone": "^0.1.2"
+				"for-own": "1.0.0",
+				"is-plain-object": "2.0.4",
+				"kind-of": "3.2.2",
+				"shallow-clone": "0.1.2"
 			}
 		},
 		"co": {
@@ -1504,7 +1688,7 @@
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
 			"dev": true,
 			"requires": {
-				"q": "^1.1.2"
+				"q": "1.5.0"
 			}
 		},
 		"code-point-at": {
@@ -1518,15 +1702,25 @@
 			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.29.0.tgz",
 			"integrity": "sha512-nlG9m0YQ0gFhdEdnKDG+XJRB/bW+K6M9Axs01+LScjVamWtd4dEwgyohf/r4voW1efnGi6U6hHHvDQ9tt9BtoA=="
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
+			}
+		},
 		"color": {
 			"version": "0.11.4",
 			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
+				"clone": "1.0.2",
+				"color-convert": "1.9.0",
+				"color-string": "0.3.0"
 			}
 		},
 		"color-convert": {
@@ -1535,7 +1729,7 @@
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -1550,7 +1744,7 @@
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.0.0"
+				"color-name": "1.1.3"
 			}
 		},
 		"colormin": {
@@ -1559,9 +1753,9 @@
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
 			"dev": true,
 			"requires": {
-				"color": "^0.11.0",
+				"color": "0.11.4",
 				"css-color-names": "0.0.4",
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"colors": {
@@ -1576,13 +1770,23 @@
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
+		},
+		"commander": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
 		"compressible": {
@@ -1591,7 +1795,7 @@
 			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
 			"dev": true,
 			"requires": {
-				"mime-db": ">= 1.29.0 < 2"
+				"mime-db": "1.30.0"
 			}
 		},
 		"compression": {
@@ -1600,20 +1804,30 @@
 			"integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.3",
+				"accepts": "1.3.4",
 				"bytes": "2.5.0",
-				"compressible": "~2.0.10",
+				"compressible": "2.0.11",
 				"debug": "2.6.8",
-				"on-headers": "~1.0.1",
+				"on-headers": "1.0.1",
 				"safe-buffer": "5.1.1",
-				"vary": "~1.1.1"
+				"vary": "1.1.1"
 			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"requires": {
+				"buffer-from": "1.1.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			}
 		},
 		"connect-history-api-fallback": {
 			"version": "1.3.0",
@@ -1627,7 +1841,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "^0.1.4"
+				"date-now": "0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -1672,6 +1886,25 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
 			"dev": true
 		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
 		"core-js": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -1680,43 +1913,43 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-ecdh": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.1"
 			}
 		},
 		"create-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"version": "1.2.0",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"sha.js": "^2.4.0"
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"md5.js": "1.3.5",
+				"ripemd160": "2.0.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-hmac": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"version": "1.1.7",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-react-class": {
@@ -1724,9 +1957,37 @@
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
 			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
 			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"cross-env": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+			"integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+			"requires": {
+				"cross-spawn": "6.0.5",
+				"is-windows": "1.0.2"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"requires": {
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.6.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
+					}
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+				}
 			}
 		},
 		"cross-spawn": {
@@ -1735,26 +1996,27 @@
 			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.1",
+				"which": "1.3.0"
 			}
 		},
 		"crypto-browserify": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"browserify-cipher": "1.0.1",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.3",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"diffie-hellman": "5.0.3",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.17",
+				"public-encrypt": "4.0.3",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.4"
 			}
 		},
 		"css-color-names": {
@@ -1769,20 +2031,20 @@
 			"integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.11.0",
-				"css-selector-tokenizer": "^0.7.0",
-				"cssnano": ">=2.6.1 <4",
-				"icss-utils": "^2.1.0",
-				"loader-utils": "^1.0.2",
-				"lodash.camelcase": "^4.3.0",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.6",
-				"postcss-modules-extract-imports": "^1.0.0",
-				"postcss-modules-local-by-default": "^1.0.1",
-				"postcss-modules-scope": "^1.0.0",
-				"postcss-modules-values": "^1.1.0",
-				"postcss-value-parser": "^3.3.0",
-				"source-list-map": "^2.0.0"
+				"babel-code-frame": "6.26.0",
+				"css-selector-tokenizer": "0.7.0",
+				"cssnano": "3.10.0",
+				"icss-utils": "2.1.0",
+				"loader-utils": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-modules-extract-imports": "1.1.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0",
+				"postcss-value-parser": "3.3.0",
+				"source-list-map": "2.0.0"
 			}
 		},
 		"css-selector-tokenizer": {
@@ -1791,9 +2053,9 @@
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
 			"dev": true,
 			"requires": {
-				"cssesc": "^0.1.0",
-				"fastparse": "^1.1.1",
-				"regexpu-core": "^1.0.0"
+				"cssesc": "0.1.0",
+				"fastparse": "1.1.1",
+				"regexpu-core": "1.0.0"
 			},
 			"dependencies": {
 				"regexpu-core": {
@@ -1802,9 +2064,9 @@
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
 					"dev": true,
 					"requires": {
-						"regenerate": "^1.2.1",
-						"regjsgen": "^0.2.0",
-						"regjsparser": "^0.1.4"
+						"regenerate": "1.3.3",
+						"regjsgen": "0.2.0",
+						"regjsparser": "0.1.5"
 					}
 				}
 			}
@@ -1821,38 +2083,38 @@
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "^6.3.1",
-				"decamelize": "^1.1.2",
-				"defined": "^1.0.0",
-				"has": "^1.0.1",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.14",
-				"postcss-calc": "^5.2.0",
-				"postcss-colormin": "^2.1.8",
-				"postcss-convert-values": "^2.3.4",
-				"postcss-discard-comments": "^2.0.4",
-				"postcss-discard-duplicates": "^2.0.1",
-				"postcss-discard-empty": "^2.0.1",
-				"postcss-discard-overridden": "^0.1.1",
-				"postcss-discard-unused": "^2.2.1",
-				"postcss-filter-plugins": "^2.0.0",
-				"postcss-merge-idents": "^2.1.5",
-				"postcss-merge-longhand": "^2.0.1",
-				"postcss-merge-rules": "^2.0.3",
-				"postcss-minify-font-values": "^1.0.2",
-				"postcss-minify-gradients": "^1.0.1",
-				"postcss-minify-params": "^1.0.4",
-				"postcss-minify-selectors": "^2.0.4",
-				"postcss-normalize-charset": "^1.1.0",
-				"postcss-normalize-url": "^3.0.7",
-				"postcss-ordered-values": "^2.1.0",
-				"postcss-reduce-idents": "^2.2.2",
-				"postcss-reduce-initial": "^1.0.0",
-				"postcss-reduce-transforms": "^1.0.3",
-				"postcss-svgo": "^2.1.1",
-				"postcss-unique-selectors": "^2.0.2",
-				"postcss-value-parser": "^3.2.3",
-				"postcss-zindex": "^2.0.1"
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.1",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.2",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
 			}
 		},
 		"csso": {
@@ -1861,8 +2123,8 @@
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
 			"dev": true,
 			"requires": {
-				"clap": "^1.0.9",
-				"source-map": "^0.5.3"
+				"clap": "1.2.2",
+				"source-map": "0.5.7"
 			}
 		},
 		"currently-unhandled": {
@@ -1871,7 +2133,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"curry": {
@@ -1879,13 +2141,18 @@
 			"resolved": "http://registry.npmjs.org/curry/-/curry-1.2.0.tgz",
 			"integrity": "sha1-nm3SiVSNun5lPVrj/pA/59+zOvI="
 		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+		},
 		"d": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "0.10.46"
 			}
 		},
 		"dashdash": {
@@ -1894,7 +2161,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"date-now": {
@@ -1918,6 +2185,12 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -1936,8 +2209,8 @@
 			"integrity": "sha512-Mb+xi1aktPE+Uz5RmS3vU6Kr1fDqRvlMX3M5eneBai7LkldzM+WPjaUpz396taZgOgSw4s+CJGvd6VJJ/9W0dQ==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"ip-regex": "^2.1.0"
+				"execa": "0.7.0",
+				"ip-regex": "2.1.0"
 			}
 		},
 		"define-properties": {
@@ -1946,8 +2219,55 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
 		"defined": {
@@ -1962,12 +2282,12 @@
 			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"dev": true,
 			"requires": {
-				"globby": "^6.1.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"p-map": "^1.1.1",
-				"pify": "^3.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.6.2"
 			},
 			"dependencies": {
 				"pify": {
@@ -2002,8 +2322,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"destroy": {
@@ -2018,7 +2338,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-node": {
@@ -2028,14 +2348,14 @@
 			"dev": true
 		},
 		"diffie-hellman": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"version": "5.0.3",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
 			}
 		},
 		"discontinuous-range": {
@@ -2055,8 +2375,8 @@
 			"integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.0",
-				"safe-buffer": "^5.0.1"
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"dns-txt": {
@@ -2065,7 +2385,7 @@
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
 			"dev": true,
 			"requires": {
-				"buffer-indexof": "^1.0.0"
+				"buffer-indexof": "1.1.1"
 			}
 		},
 		"doctrine": {
@@ -2074,14 +2394,25 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"domain-browser": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
+		},
+		"duplexify": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -2090,8 +2421,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ee-first": {
@@ -2107,18 +2438,18 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.5",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"emojis-list": {
@@ -2138,7 +2469,15 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -2147,10 +2486,10 @@
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"object-assign": "^4.0.1",
-				"tapable": "^0.2.7"
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
 			}
 		},
 		"errno": {
@@ -2159,7 +2498,7 @@
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"dev": true,
 			"requires": {
-				"prr": "~0.0.0"
+				"prr": "0.0.0"
 			}
 		},
 		"error-ex": {
@@ -2168,7 +2507,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2177,11 +2516,11 @@
 			"integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -2190,30 +2529,31 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.30",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-			"integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+			"version": "0.10.46",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
 			"dev": true,
 			"requires": {
-				"es6-iterator": "2",
-				"es6-symbol": "~3.1"
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"next-tick": "1.0.0"
 			}
 		},
 		"es6-iterator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-symbol": "^3.1"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"es6-map": {
@@ -2222,12 +2562,12 @@
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-set": "~0.1.5",
-				"es6-symbol": "~3.1.1",
-				"event-emitter": "~0.3.5"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
 			}
 		},
 		"es6-set": {
@@ -2236,11 +2576,11 @@
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
+				"event-emitter": "0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -2249,8 +2589,8 @@
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46"
 			}
 		},
 		"es6-weak-map": {
@@ -2259,10 +2599,10 @@
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
-				"es6-symbol": "^3.1.1"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"escape-html": {
@@ -2283,10 +2623,10 @@
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"dev": true,
 			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint": {
@@ -2295,44 +2635,44 @@
 			"integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.0",
-				"babel-code-frame": "^6.26.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^4.0.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^4.0.0",
-				"esquery": "^1.0.1",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.5.0",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^5.2.0",
-				"is-resolvable": "^1.1.0",
-				"js-yaml": "^3.11.0",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.5",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"regexpp": "^1.1.0",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.5.0",
-				"string.prototype.matchall": "^2.0.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
-				"table": "^4.0.3",
-				"text-table": "^0.2.0"
+				"ajv": "6.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "4.0.0",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "4.0.0",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.7.0",
+				"ignore": "3.3.10",
+				"imurmurhash": "0.1.4",
+				"inquirer": "5.2.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.12.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"string.prototype.matchall": "2.0.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.3",
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -2341,10 +2681,10 @@
 					"integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.1"
+						"fast-deep-equal": "2.0.1",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.4.1",
+						"uri-js": "4.2.2"
 					}
 				},
 				"ansi-regex": {
@@ -2359,7 +2699,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -2368,9 +2708,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"cross-spawn": {
@@ -2379,11 +2719,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				},
 				"debug": {
@@ -2425,8 +2765,8 @@
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"argparse": "1.0.9",
+						"esprima": "4.0.0"
 					}
 				},
 				"json-schema-traverse": {
@@ -2453,7 +2793,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -2462,7 +2802,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -2473,8 +2813,8 @@
 			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2489,8 +2829,8 @@
 			"integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.6.0",
-				"acorn-jsx": "^4.1.1"
+				"acorn": "5.7.1",
+				"acorn-jsx": "4.1.1"
 			},
 			"dependencies": {
 				"acorn": {
@@ -2513,7 +2853,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -2522,8 +2862,8 @@
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0",
-				"object-assign": "^4.0.1"
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"estraverse": {
@@ -2550,8 +2890,8 @@
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46"
 			}
 		},
 		"eventemitter3": {
@@ -2572,7 +2912,7 @@
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
 			"dev": true,
 			"requires": {
-				"original": ">=0.0.5"
+				"original": "1.0.0"
 			}
 		},
 		"evp_bytestokey": {
@@ -2581,8 +2921,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
+				"md5.js": "1.3.5",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"execa": {
@@ -2591,13 +2931,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -2606,9 +2946,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.1",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				}
 			}
@@ -2619,7 +2959,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -2628,7 +2968,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.3"
 			}
 		},
 		"express": {
@@ -2637,34 +2977,34 @@
 			"integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.3",
+				"accepts": "1.3.4",
 				"array-flatten": "1.1.1",
 				"content-disposition": "0.5.2",
-				"content-type": "~1.0.2",
+				"content-type": "1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.8",
-				"depd": "~1.1.1",
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.0",
-				"finalhandler": "~1.0.4",
+				"depd": "1.1.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.0.5",
 				"fresh": "0.5.0",
 				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~1.1.5",
+				"proxy-addr": "1.1.5",
 				"qs": "6.5.0",
-				"range-parser": "~1.2.0",
+				"range-parser": "1.2.0",
 				"send": "0.15.4",
 				"serve-static": "1.12.4",
 				"setprototypeof": "1.0.3",
-				"statuses": "~1.3.1",
-				"type-is": "~1.6.15",
+				"statuses": "1.3.1",
+				"type-is": "1.6.15",
 				"utils-merge": "1.0.0",
-				"vary": "~1.1.1"
+				"vary": "1.1.1"
 			},
 			"dependencies": {
 				"array-flatten": {
@@ -2687,15 +3027,36 @@
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
 		"external-editor": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2704,7 +3065,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -2722,8 +3083,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -2743,7 +3103,7 @@
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
 			"dev": true,
 			"requires": {
-				"websocket-driver": ">=0.5.1"
+				"websocket-driver": "0.7.0"
 			}
 		},
 		"fbjs": {
@@ -2751,13 +3111,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
 			"integrity": "sha1-TwaV/fzBbDfAsH+s7Iy0xAkWhbk=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.14"
 			},
 			"dependencies": {
 				"core-js": {
@@ -2773,7 +3133,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -2782,8 +3142,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"file-loader": {
@@ -2792,7 +3152,7 @@
 			"integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.0.2"
+				"loader-utils": "1.1.0"
 			}
 		},
 		"filename-regex": {
@@ -2807,11 +3167,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2832,32 +3192,30 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.3.1",
-				"unpipe": "~1.0.0"
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
 			}
 		},
 		"find-cache-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.0.0",
+				"pkg-dir": "2.0.0"
 			}
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -2866,10 +3224,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			},
 			"dependencies": {
 				"del": {
@@ -2878,13 +3236,13 @@
 					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 					"dev": true,
 					"requires": {
-						"globby": "^5.0.0",
-						"is-path-cwd": "^1.0.0",
-						"is-path-in-cwd": "^1.0.0",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"rimraf": "^2.2.8"
+						"globby": "5.0.0",
+						"is-path-cwd": "1.0.0",
+						"is-path-in-cwd": "1.0.0",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"rimraf": "2.6.2"
 					}
 				},
 				"globby": {
@@ -2893,12 +3251,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -2908,6 +3266,15 @@
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
 			"dev": true
+		},
+		"flush-write-stream": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2921,7 +3288,7 @@
 			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -2942,9 +3309,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.17"
 			},
 			"dependencies": {
 				"combined-stream": {
@@ -2953,7 +3320,7 @@
 					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				}
 			}
@@ -2964,17 +3331,45 @@
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "0.2.2"
+			}
+		},
 		"fresh": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
 			"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
 			"dev": true
 		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.1.2",
@@ -2983,8 +3378,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.36"
+				"nan": "2.7.0",
+				"node-pre-gyp": "0.6.36"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3001,8 +3396,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -3025,8 +3420,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
 					}
 				},
 				"asn1": {
@@ -3077,7 +3472,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "^0.14.3"
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"block-stream": {
@@ -3086,7 +3481,7 @@
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
-						"inherits": "~2.0.0"
+						"inherits": "2.0.3"
 					}
 				},
 				"boom": {
@@ -3095,7 +3490,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"brace-expansion": {
@@ -3104,7 +3499,7 @@
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
-						"balanced-match": "^0.4.1",
+						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3140,7 +3535,7 @@
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
@@ -3168,7 +3563,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.x.x"
+						"boom": "2.10.1"
 					}
 				},
 				"dashdash": {
@@ -3178,7 +3573,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3227,7 +3622,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"extend": {
@@ -3257,9 +3652,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
 					}
 				},
 				"fs.realpath": {
@@ -3274,10 +3669,10 @@
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
 					}
 				},
 				"fstream-ignore": {
@@ -3287,9 +3682,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
 					}
 				},
 				"gauge": {
@@ -3299,14 +3694,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"getpass": {
@@ -3316,7 +3711,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3334,12 +3729,12 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"graceful-fs": {
@@ -3362,8 +3757,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -3380,10 +3775,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
 					}
 				},
 				"hoek": {
@@ -3399,9 +3794,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
 					}
 				},
 				"inflight": {
@@ -3410,8 +3805,8 @@
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -3433,7 +3828,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-typedarray": {
@@ -3463,7 +3858,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"jsbn": {
@@ -3487,7 +3882,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsonify": "~0.0.0"
+						"jsonify": "0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -3538,7 +3933,7 @@
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
-						"mime-db": "~1.27.0"
+						"mime-db": "1.27.0"
 					}
 				},
 				"minimatch": {
@@ -3547,7 +3942,7 @@
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
@@ -3579,15 +3974,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"request": "^2.81.0",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
 					}
 				},
 				"nopt": {
@@ -3597,8 +3992,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
 					}
 				},
 				"npmlog": {
@@ -3608,10 +4003,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3640,7 +4035,7 @@
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -3664,8 +4059,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -3708,10 +4103,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3729,13 +4124,13 @@
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
-						"buffer-shims": "~1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
-						"util-deprecate": "~1.0.1"
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"request": {
@@ -3745,28 +4140,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
 					}
 				},
 				"rimraf": {
@@ -3775,7 +4170,7 @@
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -3812,7 +4207,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"sshpk": {
@@ -3822,15 +4217,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3848,9 +4243,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -3859,7 +4254,7 @@
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -3875,7 +4270,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -3891,9 +4286,9 @@
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
 					}
 				},
 				"tar-pack": {
@@ -3903,14 +4298,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -3920,7 +4315,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"punycode": "^1.4.1"
+						"punycode": "1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -3930,7 +4325,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -3977,7 +4372,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3994,10 +4389,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"function-bind": {
@@ -4018,14 +4413,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.3"
 			}
 		},
 		"gaze": {
@@ -4034,7 +4429,7 @@
 			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
 			"requires": {
-				"globule": "^1.0.0"
+				"globule": "1.2.1"
 			}
 		},
 		"get-caller-file": {
@@ -4055,27 +4450,32 @@
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -4084,8 +4484,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -4094,7 +4494,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"globals": {
@@ -4109,11 +4509,11 @@
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"globule": {
@@ -4122,9 +4522,9 @@
 			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
 			"dev": true,
 			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
-				"minimatch": "~3.0.2"
+				"glob": "7.1.2",
+				"lodash": "4.17.11",
+				"minimatch": "3.0.4"
 			},
 			"dependencies": {
 				"lodash": {
@@ -4138,8 +4538,7 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"handle-thing": {
 			"version": "1.2.5",
@@ -4159,8 +4558,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -4169,7 +4568,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -4178,7 +4577,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -4199,23 +4598,84 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
-		"hash-base": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				}
+			}
+		},
+		"hash-base": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"hash.js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
+			},
+			"dependencies": {
+				"minimalistic-assert": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+					"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+					"dev": true
+				}
 			}
 		},
 		"hmac-drbg": {
@@ -4224,9 +4684,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.5",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"home-or-tmp": {
@@ -4235,8 +4695,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -4251,10 +4711,10 @@
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"obuf": "^1.0.0",
-				"readable-stream": "^2.0.1",
-				"wbuf": "^1.1.0"
+				"inherits": "2.0.3",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"wbuf": "1.7.2"
 			}
 		},
 		"html-comment-regex": {
@@ -4284,7 +4744,7 @@
 				"depd": "1.1.1",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.0.3",
-				"statuses": ">= 1.3.1 < 2"
+				"statuses": "1.3.1"
 			}
 		},
 		"http-parser-js": {
@@ -4299,8 +4759,8 @@
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "1.x.x",
-				"requires-port": "1.x.x"
+				"eventemitter3": "1.2.0",
+				"requires-port": "1.0.0"
 			}
 		},
 		"http-proxy-middleware": {
@@ -4309,10 +4769,10 @@
 			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
 			"dev": true,
 			"requires": {
-				"http-proxy": "^1.16.2",
-				"is-glob": "^3.1.0",
-				"lodash": "^4.17.2",
-				"micromatch": "^2.3.11"
+				"http-proxy": "1.16.2",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -4327,7 +4787,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"is-extglob": "2.1.1"
 					}
 				}
 			}
@@ -4338,15 +4798,15 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.2"
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -4366,7 +4826,7 @@
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "6.0.11"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4375,7 +4835,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -4384,9 +4844,9 @@
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
 					}
 				},
 				"has-flag": {
@@ -4401,9 +4861,9 @@
 					"integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.1.0",
-						"source-map": "^0.5.7",
-						"supports-color": "^4.4.0"
+						"chalk": "2.1.0",
+						"source-map": "0.5.7",
+						"supports-color": "4.4.0"
 					}
 				},
 				"supports-color": {
@@ -4412,16 +4872,21 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
 			"dev": true
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -4432,8 +4897,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -4447,7 +4911,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"indexes-of": {
@@ -4466,17 +4930,15 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
 			"version": "5.2.0",
@@ -4484,19 +4946,19 @@
 			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.1.0",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^5.5.2",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rxjs": "5.5.11",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4511,7 +4973,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -4520,9 +4982,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"has-flag": {
@@ -4543,8 +5005,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4553,7 +5015,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4562,7 +5024,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4573,8 +5035,8 @@
 			"integrity": "sha512-XxJMiJOjXbb9LlwH6SVTsnUPymYACunXzKg3dqU+HIC+xYIkUhMyTiT/H6xxPmhlE4zHq50lKlx0CZlyN2C76Q==",
 			"dev": true,
 			"requires": {
-				"default-gateway": "^2.2.2",
-				"ipaddr.js": "^1.5.2"
+				"default-gateway": "2.5.0",
+				"ipaddr.js": "1.5.2"
 			},
 			"dependencies": {
 				"ipaddr.js": {
@@ -4586,9 +5048,9 @@
 			}
 		},
 		"interpret": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
 			"dev": true
 		},
 		"invariant": {
@@ -4596,7 +5058,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -4629,6 +5091,15 @@
 			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
 			"dev": true
 		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4641,7 +5112,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.10.0"
 			}
 		},
 		"is-buffer": {
@@ -4656,7 +5127,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -4665,11 +5136,39 @@
 			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
 			"dev": true
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -4683,7 +5182,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4704,7 +5203,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4713,7 +5212,7 @@
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-glob": {
@@ -4722,7 +5221,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-number": {
@@ -4731,7 +5230,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-path-cwd": {
@@ -4746,7 +5245,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -4755,7 +5254,7 @@
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -4770,7 +5269,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -4797,7 +5296,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -4817,7 +5316,7 @@
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
 			"dev": true,
 			"requires": {
-				"html-comment-regex": "^1.1.0"
+				"html-comment-regex": "1.1.1"
 			}
 		},
 		"is-symbol": {
@@ -4838,6 +5337,11 @@
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
 			"dev": true
 		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -4847,14 +5351,12 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -4867,8 +5369,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
 			}
 		},
 		"isstream": {
@@ -4899,8 +5401,8 @@
 			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^2.6.0"
+				"argparse": "1.0.9",
+				"esprima": "2.7.3"
 			}
 		},
 		"jsbn": {
@@ -4940,7 +5442,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -4991,7 +5493,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "^1.1.5"
+				"is-buffer": "1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -5006,7 +5508,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"levn": {
@@ -5015,8 +5517,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -5025,17 +5527,17 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"loader-runner": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
+			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
 			"dev": true
 		},
 		"loader-utils": {
@@ -5044,19 +5546,18 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -5080,6 +5581,12 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
 		"lodash.memoize": {
@@ -5123,7 +5630,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -5132,18 +5639,17 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lru-cache": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"macaddress": {
@@ -5156,16 +5662,30 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
 			"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-			"dev": true,
 			"requires": {
-				"pify": "^2.3.0"
+				"pify": "2.3.0"
 			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "1.0.1"
+			}
 		},
 		"math-expression-evaluator": {
 			"version": "1.2.17",
@@ -5174,24 +5694,21 @@
 			"dev": true
 		},
 		"md5.js": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			},
 			"dependencies": {
-				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				}
 			}
 		},
@@ -5207,7 +5724,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.1.0"
 			}
 		},
 		"memory-fs": {
@@ -5216,8 +5733,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"errno": "0.1.4",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"meow": {
@@ -5226,16 +5743,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -5264,29 +5781,29 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
 			}
 		},
 		"miller-rabin": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
-			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
 			}
 		},
 		"mime": {
@@ -5307,7 +5824,7 @@
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.30.0"
+				"mime-db": "1.30.0"
 			}
 		},
 		"mimic-fn": {
@@ -5332,16 +5849,52 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.8"
 			}
 		},
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mississippi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"requires": {
+				"concat-stream": "1.6.2",
+				"duplexify": "3.6.1",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.3",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.5.1",
+				"stream-each": "1.2.3",
+				"through2": "2.0.3"
+			}
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
 		},
 		"mixin-object": {
 			"version": "2.0.1",
@@ -5349,8 +5902,8 @@
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
+				"for-in": "0.1.8",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-in": {
@@ -5365,7 +5918,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -5374,6 +5926,19 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
 			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -5387,8 +5952,8 @@
 			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
 			"dev": true,
 			"requires": {
-				"dns-packet": "^1.0.1",
-				"thunky": "^0.1.0"
+				"dns-packet": "1.2.2",
+				"thunky": "0.1.0"
 			}
 		},
 		"multicast-dns-service-types": {
@@ -5410,6 +5975,45 @@
 			"dev": true,
 			"optional": true
 		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5421,11 +6025,11 @@
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
 			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
 			"requires": {
-				"moo": "^0.4.3",
-				"nomnom": "~1.6.2",
-				"railroad-diagrams": "^1.0.0",
+				"moo": "0.4.3",
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
 				"randexp": "0.4.6",
-				"semver": "^5.4.1"
+				"semver": "5.4.1"
 			}
 		},
 		"negotiator": {
@@ -5434,19 +6038,30 @@
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
-			"dev": true
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"node-forge": {
@@ -5461,18 +6076,18 @@
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"dev": true,
 			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
+				"fstream": "1.0.11",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"npmlog": "4.1.2",
+				"osenv": "0.1.5",
+				"request": "2.87.0",
+				"rimraf": "2.6.2",
+				"semver": "5.3.0",
+				"tar": "2.2.1",
+				"which": "1.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -5484,42 +6099,34 @@
 			}
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.1.4",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
-				"https-browserify": "0.0.1",
-				"os-browserify": "^0.2.0",
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.0",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.0.5",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.3.1",
-				"string_decoder": "^0.10.25",
-				"timers-browserify": "^2.0.2",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.3",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.3",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.10",
 				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"url": "0.11.0",
+				"util": "0.10.4",
 				"vm-browserify": "0.0.4"
-			},
-			"dependencies": {
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
 			}
 		},
 		"node-sass": {
@@ -5528,25 +6135,25 @@
 			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
 			"dev": true,
 			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
-				"node-gyp": "^3.8.0",
-				"npmlog": "^4.0.0",
+				"async-foreach": "0.1.3",
+				"chalk": "1.1.3",
+				"cross-spawn": "3.0.1",
+				"gaze": "1.1.3",
+				"get-stdin": "4.0.1",
+				"glob": "7.1.2",
+				"in-publish": "2.0.0",
+				"lodash.assign": "4.2.0",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.mergewith": "4.6.1",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"nan": "2.11.1",
+				"node-gyp": "3.8.0",
+				"npmlog": "4.1.2",
 				"request": "2.87.0",
-				"sass-graph": "^2.2.4",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
+				"sass-graph": "2.2.4",
+				"stdout-stream": "1.4.1",
+				"true-case-path": "1.0.3"
 			},
 			"dependencies": {
 				"nan": {
@@ -5562,8 +6169,8 @@
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
 			"requires": {
-				"colors": "0.5.x",
-				"underscore": "~1.4.4"
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
 			},
 			"dependencies": {
 				"colors": {
@@ -5579,7 +6186,7 @@
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"dev": true,
 			"requires": {
-				"abbrev": "1"
+				"abbrev": "1.1.1"
 			}
 		},
 		"normalize-package-data": {
@@ -5588,10 +6195,10 @@
 			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -5600,7 +6207,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-range": {
@@ -5615,10 +6222,10 @@
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
 			}
 		},
 		"npm-run-path": {
@@ -5627,7 +6234,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npmlog": {
@@ -5636,10 +6243,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
+				"are-we-there-yet": "1.1.5",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
 			}
 		},
 		"num2fraction": {
@@ -5665,11 +6272,42 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				}
+			}
+		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
 			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
 			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
@@ -5677,8 +6315,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-own": {
@@ -5687,9 +6325,18 @@
 					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.1"
+						"for-in": "1.0.2"
 					}
 				}
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
 			}
 		},
 		"obuf": {
@@ -5717,9 +6364,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -5728,7 +6374,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.1.0"
 			}
 		},
 		"opn": {
@@ -5737,7 +6383,7 @@
 			"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
 			"dev": true,
 			"requires": {
-				"is-wsl": "^1.1.0"
+				"is-wsl": "1.1.0"
 			}
 		},
 		"optionator": {
@@ -5746,12 +6392,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -5768,7 +6414,7 @@
 			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
 			"dev": true,
 			"requires": {
-				"url-parse": "1.0.x"
+				"url-parse": "1.0.5"
 			},
 			"dependencies": {
 				"url-parse": {
@@ -5777,16 +6423,16 @@
 					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
 					"dev": true,
 					"requires": {
-						"querystringify": "0.0.x",
-						"requires-port": "1.0.x"
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
 					}
 				}
 			}
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
 			"dev": true
 		},
 		"os-homedir": {
@@ -5801,7 +6447,7 @@
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
-				"lcid": "^1.0.0"
+				"lcid": "1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -5816,8 +6462,8 @@
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"p-finally": {
@@ -5829,16 +6475,14 @@
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-			"dev": true
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.1.0"
 			}
 		},
 		"p-map": {
@@ -5848,22 +6492,32 @@
 			"dev": true
 		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
 			"dev": true
 		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
 		"parse-asn1": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"version": "5.1.1",
+			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.2.0",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.17"
 			}
 		},
 		"parse-glob": {
@@ -5872,10 +6526,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -5884,7 +6538,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parseurl": {
@@ -5893,23 +6547,33 @@
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
 			"dev": true
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
 			"dev": true
 		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -5920,8 +6584,7 @@
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -5935,22 +6598,22 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"pbkdf2": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"performance-now": {
@@ -5962,8 +6625,7 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -5977,16 +6639,15 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"pluralize": {
@@ -6001,9 +6662,9 @@
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 			"dev": true,
 			"requires": {
-				"async": "^1.5.2",
-				"debug": "^2.2.0",
-				"mkdirp": "0.5.x"
+				"async": "1.5.2",
+				"debug": "2.6.8",
+				"mkdirp": "0.5.1"
 			},
 			"dependencies": {
 				"async": {
@@ -6014,16 +6675,22 @@
 				}
 			}
 		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
 		"postcss": {
 			"version": "5.2.17",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
 			"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"js-base64": "^2.1.9",
-				"source-map": "^0.5.6",
-				"supports-color": "^3.2.3"
+				"chalk": "1.1.3",
+				"js-base64": "2.3.2",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -6032,7 +6699,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -6043,9 +6710,9 @@
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.2",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-css-calc": "^1.2.6"
+				"postcss": "5.2.17",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
 			}
 		},
 		"postcss-colormin": {
@@ -6054,9 +6721,9 @@
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
 			"dev": true,
 			"requires": {
-				"colormin": "^1.0.5",
-				"postcss": "^5.0.13",
-				"postcss-value-parser": "^3.2.3"
+				"colormin": "1.1.2",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-convert-values": {
@@ -6065,8 +6732,8 @@
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.11",
-				"postcss-value-parser": "^3.1.2"
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-discard-comments": {
@@ -6075,7 +6742,7 @@
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -6084,7 +6751,7 @@
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-discard-empty": {
@@ -6093,7 +6760,7 @@
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-discard-overridden": {
@@ -6102,7 +6769,7 @@
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.16"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-discard-unused": {
@@ -6111,8 +6778,8 @@
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.14",
-				"uniqs": "^2.0.0"
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-filter-plugins": {
@@ -6121,8 +6788,8 @@
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"uniqid": "^4.0.0"
+				"postcss": "5.2.17",
+				"uniqid": "4.1.1"
 			}
 		},
 		"postcss-merge-idents": {
@@ -6131,9 +6798,9 @@
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.10",
-				"postcss-value-parser": "^3.1.1"
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-merge-longhand": {
@@ -6142,7 +6809,7 @@
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-merge-rules": {
@@ -6151,11 +6818,11 @@
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
 			"dev": true,
 			"requires": {
-				"browserslist": "^1.5.2",
-				"caniuse-api": "^1.5.2",
-				"postcss": "^5.0.4",
-				"postcss-selector-parser": "^2.2.2",
-				"vendors": "^1.0.0"
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.17",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.1"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -6164,8 +6831,8 @@
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 					"dev": true,
 					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
+						"caniuse-db": "1.0.30000733",
+						"electron-to-chromium": "1.3.21"
 					}
 				}
 			}
@@ -6182,9 +6849,9 @@
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-gradients": {
@@ -6193,8 +6860,8 @@
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.12",
-				"postcss-value-parser": "^3.3.0"
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-params": {
@@ -6203,10 +6870,10 @@
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.2",
-				"postcss-value-parser": "^3.0.2",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-minify-selectors": {
@@ -6215,10 +6882,10 @@
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"has": "^1.0.1",
-				"postcss": "^5.0.14",
-				"postcss-selector-parser": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-selector-parser": "2.2.3"
 			}
 		},
 		"postcss-modules-extract-imports": {
@@ -6227,7 +6894,7 @@
 			"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "6.0.11"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6236,7 +6903,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -6245,9 +6912,9 @@
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
 					}
 				},
 				"has-flag": {
@@ -6262,9 +6929,9 @@
 					"integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.1.0",
-						"source-map": "^0.5.7",
-						"supports-color": "^4.4.0"
+						"chalk": "2.1.0",
+						"source-map": "0.5.7",
+						"supports-color": "4.4.0"
 					}
 				},
 				"supports-color": {
@@ -6273,7 +6940,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -6284,8 +6951,8 @@
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.11"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6294,7 +6961,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -6303,9 +6970,9 @@
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
 					}
 				},
 				"has-flag": {
@@ -6320,9 +6987,9 @@
 					"integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.1.0",
-						"source-map": "^0.5.7",
-						"supports-color": "^4.4.0"
+						"chalk": "2.1.0",
+						"source-map": "0.5.7",
+						"supports-color": "4.4.0"
 					}
 				},
 				"supports-color": {
@@ -6331,7 +6998,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -6342,8 +7009,8 @@
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.11"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6352,7 +7019,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -6361,9 +7028,9 @@
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
 					}
 				},
 				"has-flag": {
@@ -6378,9 +7045,9 @@
 					"integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.1.0",
-						"source-map": "^0.5.7",
-						"supports-color": "^4.4.0"
+						"chalk": "2.1.0",
+						"source-map": "0.5.7",
+						"supports-color": "4.4.0"
 					}
 				},
 				"supports-color": {
@@ -6389,7 +7056,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -6400,8 +7067,8 @@
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
 			"dev": true,
 			"requires": {
-				"icss-replace-symbols": "^1.1.0",
-				"postcss": "^6.0.1"
+				"icss-replace-symbols": "1.1.0",
+				"postcss": "6.0.11"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6410,7 +7077,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -6419,9 +7086,9 @@
 					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
 					}
 				},
 				"has-flag": {
@@ -6436,9 +7103,9 @@
 					"integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.1.0",
-						"source-map": "^0.5.7",
-						"supports-color": "^4.4.0"
+						"chalk": "2.1.0",
+						"source-map": "0.5.7",
+						"supports-color": "4.4.0"
 					}
 				},
 				"supports-color": {
@@ -6447,7 +7114,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -6458,7 +7125,7 @@
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.5"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-normalize-url": {
@@ -6467,10 +7134,10 @@
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"dev": true,
 			"requires": {
-				"is-absolute-url": "^2.0.0",
-				"normalize-url": "^1.4.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3"
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-ordered-values": {
@@ -6479,8 +7146,8 @@
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.1"
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-idents": {
@@ -6489,8 +7156,8 @@
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-initial": {
@@ -6499,7 +7166,7 @@
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.17"
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -6508,9 +7175,9 @@
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.8",
-				"postcss-value-parser": "^3.0.1"
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-selector-parser": {
@@ -6519,9 +7186,9 @@
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"dev": true,
 			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
 			}
 		},
 		"postcss-svgo": {
@@ -6530,10 +7197,10 @@
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"dev": true,
 			"requires": {
-				"is-svg": "^2.0.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3",
-				"svgo": "^0.7.0"
+				"is-svg": "2.1.0",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
 			}
 		},
 		"postcss-unique-selectors": {
@@ -6542,9 +7209,9 @@
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-value-parser": {
@@ -6559,9 +7226,9 @@
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
 			}
 		},
 		"prelude-ls": {
@@ -6603,8 +7270,7 @@
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-			"dev": true
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 		},
 		"progress": {
 			"version": "2.0.0",
@@ -6617,16 +7283,21 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"prop-types": {
 			"version": "15.5.10",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
 			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
 			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1"
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1"
 			}
 		},
 		"proxy-addr": {
@@ -6635,7 +7306,7 @@
 			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
 			"dev": true,
 			"requires": {
-				"forwarded": "~0.1.0",
+				"forwarded": "0.1.2",
 				"ipaddr.js": "1.4.0"
 			}
 		},
@@ -6648,20 +7319,47 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"parse-asn1": "5.1.1",
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"requires": {
+				"duplexify": "3.6.1",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
 			}
 		},
 		"punycode": {
@@ -6688,8 +7386,8 @@
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
 			}
 		},
 		"querystring": {
@@ -6726,7 +7424,7 @@
 			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
 			"requires": {
 				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"randomatic": {
@@ -6735,8 +7433,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6745,7 +7443,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6754,7 +7452,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.5"
 							}
 						}
 					}
@@ -6765,18 +7463,28 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.5"
 					}
 				}
 			}
 		},
 		"randombytes": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.0"
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"range-parser": {
@@ -6796,11 +7504,11 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
 			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
 			"requires": {
-				"create-react-class": "^15.6.0",
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.0",
-				"prop-types": "^15.5.10"
+				"create-react-class": "15.6.0",
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.5.10"
 			}
 		},
 		"react-codemirror2": {
@@ -6813,10 +7521,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
 			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
 			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.0",
-				"prop-types": "^15.5.10"
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.5.10"
 			}
 		},
 		"react-hot-api": {
@@ -6831,8 +7539,8 @@
 			"integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
 			"dev": true,
 			"requires": {
-				"react-hot-api": "^0.4.5",
-				"source-map": "^0.4.4"
+				"react-hot-api": "0.4.7",
+				"source-map": "0.4.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6841,7 +7549,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -6852,9 +7560,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -6863,8 +7571,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6873,8 +7581,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -6883,7 +7591,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -6892,15 +7600,14 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~1.0.6",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -6909,10 +7616,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"redent": {
@@ -6921,8 +7628,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			}
 		},
 		"reduce-css-calc": {
@@ -6931,9 +7638,9 @@
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -6950,7 +7657,7 @@
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^0.4.2"
+				"balanced-match": "0.4.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -6978,9 +7685,9 @@
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.7"
 			}
 		},
 		"regex-cache": {
@@ -6989,7 +7696,17 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexp.prototype.flags": {
@@ -6998,7 +7715,7 @@
 			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2"
+				"define-properties": "1.1.2"
 			}
 		},
 		"regexpp": {
@@ -7013,9 +7730,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -7030,7 +7747,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -7065,7 +7782,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -7074,26 +7791,26 @@
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.7",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.1",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
 			}
 		},
 		"require-directory": {
@@ -7114,8 +7831,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			}
 		},
 		"requires-port": {
@@ -7130,14 +7847,20 @@
 			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
 			"dev": true
 		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -7151,26 +7874,25 @@
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"dev": true,
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
-			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"ripemd160": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"dev": true,
 			"requires": {
-				"hash-base": "^2.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			}
 		},
 		"run-async": {
@@ -7179,7 +7901,15 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"requires": {
+				"aproba": "1.2.0"
 			}
 		},
 		"rxjs": {
@@ -7194,8 +7924,16 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "0.1.15"
+			}
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -7209,10 +7947,10 @@
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
+				"glob": "7.1.2",
+				"lodash": "4.17.4",
+				"scss-tokenizer": "0.2.3",
+				"yargs": "7.1.0"
 			}
 		},
 		"sass-loader": {
@@ -7221,11 +7959,11 @@
 			"integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.5",
-				"clone-deep": "^0.3.0",
-				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
-				"pify": "^3.0.0"
+				"async": "2.5.0",
+				"clone-deep": "0.3.0",
+				"loader-utils": "1.1.0",
+				"lodash.tail": "4.1.1",
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -7248,7 +7986,7 @@
 			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.0.0"
+				"ajv": "5.2.2"
 			},
 			"dependencies": {
 				"ajv": {
@@ -7257,10 +7995,10 @@
 					"integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"json-schema-traverse": "^0.3.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.0.0",
+						"json-schema-traverse": "0.3.1",
+						"json-stable-stringify": "1.0.1"
 					}
 				}
 			}
@@ -7271,8 +8009,8 @@
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"dev": true,
 			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
+				"js-base64": "2.3.2",
+				"source-map": "0.4.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -7281,7 +8019,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -7306,7 +8044,7 @@
 			"resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.2.12.tgz",
 			"integrity": "sha512-RrA3k6hya+kEMDmVLT38SBTDQD8FgdnFi16eMPuQ1N1xUOoBxKzr+HZASb7Zo3xlMvkYqEWvPIp58Wjl6Zcsfg==",
 			"requires": {
-				"jquery": "x.*"
+				"jquery": "3.2.1"
 			}
 		},
 		"semantic-ui-react": {
@@ -7314,10 +8052,10 @@
 			"resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.73.1.tgz",
 			"integrity": "sha512-mSJMDDrl8OyeGEB1nMTRA6UeGE+FlaIx5xTg1kCsLEQLadDf32zfZscbc+kYVAXPtaYoz5wAqqmS2gP8YulO7A==",
 			"requires": {
-				"babel-runtime": "^6.25.0",
-				"classnames": "^2.2.5",
-				"lodash": "^4.17.4",
-				"prop-types": "^15.5.10"
+				"babel-runtime": "6.26.0",
+				"classnames": "2.2.5",
+				"lodash": "4.17.4",
+				"prop-types": "15.5.10"
 			}
 		},
 		"semver": {
@@ -7332,19 +8070,24 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
-				"depd": "~1.1.1",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.0",
+				"depd": "1.1.1",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"fresh": "0.5.0",
-				"http-errors": "~1.6.2",
+				"http-errors": "1.6.2",
 				"mime": "1.3.4",
 				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.3.1"
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
 			}
+		},
+		"serialize-javascript": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
 		},
 		"serve-index": {
 			"version": "1.9.0",
@@ -7352,13 +8095,13 @@
 			"integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.3",
+				"accepts": "1.3.4",
 				"batch": "0.6.1",
 				"debug": "2.6.8",
-				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.1",
-				"mime-types": "~2.1.15",
-				"parseurl": "~1.3.1"
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.2",
+				"mime-types": "2.1.17",
+				"parseurl": "1.3.2"
 			}
 		},
 		"serve-static": {
@@ -7367,9 +8110,9 @@
 			"integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
 			"dev": true,
 			"requires": {
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
 				"send": "0.15.4"
 			}
 		},
@@ -7385,6 +8128,29 @@
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
 			"dev": true
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -7397,12 +8163,13 @@
 			"dev": true
 		},
 		"sha.js": {
-			"version": "2.4.8",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
-			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+			"version": "2.4.11",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"shallow-clone": {
@@ -7411,10 +8178,10 @@
 			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
 			"dev": true,
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
+				"is-extendable": "0.1.1",
+				"kind-of": "2.0.1",
+				"lazy-cache": "0.2.7",
+				"mixin-object": "2.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7423,7 +8190,7 @@
 					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.0.2"
+						"is-buffer": "1.1.5"
 					}
 				}
 			}
@@ -7432,16 +8199,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -7461,7 +8226,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"is-fullwidth-code-point": "2.0.0"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -7472,14 +8237,116 @@
 				}
 			}
 		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "0.11.2",
+				"debug": "2.6.8",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
 		"sockjs": {
 			"version": "0.3.18",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
 			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
 			"dev": true,
 			"requires": {
-				"faye-websocket": "^0.10.0",
-				"uuid": "^2.0.2"
+				"faye-websocket": "0.10.0",
+				"uuid": "2.0.3"
 			},
 			"dependencies": {
 				"uuid": {
@@ -7496,12 +8363,12 @@
 			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.6",
+				"debug": "2.6.8",
 				"eventsource": "0.1.6",
-				"faye-websocket": "~0.11.0",
-				"inherits": "^2.0.1",
-				"json3": "^3.3.2",
-				"url-parse": "^1.1.8"
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.1.9"
 			},
 			"dependencies": {
 				"faye-websocket": {
@@ -7510,7 +8377,7 @@
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
 					"dev": true,
 					"requires": {
-						"websocket-driver": ">=0.5.1"
+						"websocket-driver": "0.7.0"
 					}
 				}
 			}
@@ -7521,14 +8388,13 @@
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -7536,14 +8402,33 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "2.1.2",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
+			}
+		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.7"
 			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
@@ -7551,7 +8436,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "^1.0.2"
+				"spdx-license-ids": "1.2.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -7572,12 +8457,12 @@
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"handle-thing": "^1.2.5",
-				"http-deceiver": "^1.2.7",
-				"safe-buffer": "^5.0.1",
-				"select-hose": "^2.0.0",
-				"spdy-transport": "^2.0.18"
+				"debug": "2.6.8",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.0.20"
 			}
 		},
 		"spdy-transport": {
@@ -7586,13 +8471,22 @@
 			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"detect-node": "^2.0.3",
-				"hpack.js": "^2.1.6",
-				"obuf": "^1.1.1",
-				"readable-stream": "^2.2.9",
-				"safe-buffer": "^5.0.1",
-				"wbuf": "^1.7.2"
+				"debug": "2.6.8",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.2"
+			}
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -7607,15 +8501,44 @@
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"ssri": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				}
 			}
 		},
 		"statuses": {
@@ -7630,7 +8553,7 @@
 			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"stream-browserify": {
@@ -7639,22 +8562,68 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-each": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.2.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
 			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -7668,9 +8637,9 @@
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"string.prototype.matchall": {
@@ -7679,11 +8648,11 @@
 			"integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.10.0",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"regexp.prototype.flags": "^1.2.0"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0",
+				"function-bind": "1.1.1",
+				"has-symbols": "1.0.0",
+				"regexp.prototype.flags": "1.2.0"
 			},
 			"dependencies": {
 				"es-abstract": {
@@ -7692,11 +8661,11 @@
 					"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 					"dev": true,
 					"requires": {
-						"es-to-primitive": "^1.1.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.1",
-						"is-callable": "^1.1.3",
-						"is-regex": "^1.0.4"
+						"es-to-primitive": "1.1.1",
+						"function-bind": "1.1.1",
+						"has": "1.0.1",
+						"is-callable": "1.1.3",
+						"is-regex": "1.0.4"
 					}
 				}
 			}
@@ -7705,9 +8674,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"strip-ansi": {
@@ -7716,7 +8684,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -7725,7 +8693,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -7740,7 +8708,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -7755,8 +8723,8 @@
 			"integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.3.0"
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0"
 			}
 		},
 		"supports-color": {
@@ -7771,13 +8739,13 @@
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
 			"dev": true,
 			"requires": {
-				"coa": "~1.0.1",
-				"colors": "~1.1.2",
-				"csso": "~2.3.1",
-				"js-yaml": "~3.7.0",
-				"mkdirp": "~0.5.1",
-				"sax": "~1.2.1",
-				"whet.extend": "~0.9.9"
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
 			}
 		},
 		"symbol-observable": {
@@ -7792,12 +8760,12 @@
 			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.0.1",
-				"ajv-keywords": "^3.0.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "6.5.2",
+				"ajv-keywords": "3.2.0",
+				"chalk": "2.4.1",
+				"lodash": "4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -7806,10 +8774,10 @@
 					"integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.1"
+						"fast-deep-equal": "2.0.1",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.4.1",
+						"uri-js": "4.2.2"
 					}
 				},
 				"ajv-keywords": {
@@ -7830,7 +8798,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.0"
 					}
 				},
 				"chalk": {
@@ -7839,9 +8807,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"fast-deep-equal": {
@@ -7874,8 +8842,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -7884,7 +8852,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -7893,7 +8861,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7910,9 +8878,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
+				"block-stream": "0.0.9",
+				"fstream": "1.0.11",
+				"inherits": "2.0.3"
 			}
 		},
 		"text-table": {
@@ -7927,6 +8895,15 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			}
+		},
 		"thunky": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -7940,12 +8917,12 @@
 			"dev": true
 		},
 		"timers-browserify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"setimmediate": "1.0.5"
 			}
 		},
 		"tmp": {
@@ -7954,7 +8931,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"to-arraybuffer": {
@@ -7969,13 +8946,55 @@
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
 			"dev": true
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				}
+			}
+		},
 		"tough-cookie": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"trim-newlines": {
@@ -7996,7 +9015,7 @@
 			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.2"
+				"glob": "7.1.2"
 			}
 		},
 		"tty-browserify": {
@@ -8011,7 +9030,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"tweetnacl": {
@@ -8027,7 +9046,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-is": {
@@ -8037,53 +9056,32 @@
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.15"
+				"mime-types": "2.1.17"
 			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"ua-parser-js": {
 			"version": "0.7.14",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
 			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
 		},
-		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"commander": "2.13.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"dev": true,
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -8095,20 +9093,101 @@
 			"optional": true
 		},
 		"uglifyjs-webpack-plugin": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-			"dev": true,
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
 			"requires": {
-				"source-map": "^0.5.6",
-				"uglify-js": "^2.8.29",
-				"webpack-sources": "^1.0.1"
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.4.7",
+				"serialize-javascript": "1.5.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.9",
+				"webpack-sources": "1.3.0",
+				"worker-farm": "1.6.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.5.4",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+					"requires": {
+						"fast-deep-equal": "2.0.1",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.4.1",
+						"uri-js": "4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
+				"schema-utils": {
+					"version": "0.4.7",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"requires": {
+						"ajv": "6.5.4",
+						"ajv-keywords": "3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"underscore": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
 			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
+					}
+				}
+			}
 		},
 		"uniq": {
 			"version": "1.0.1",
@@ -8122,7 +9201,7 @@
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
 			"dev": true,
 			"requires": {
-				"macaddress": "^0.2.8"
+				"macaddress": "0.2.8"
 			}
 		},
 		"uniqs": {
@@ -8131,28 +9210,94 @@
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
 			"dev": true
 		},
+		"unique-filename": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"requires": {
+				"unique-slug": "2.0.1"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
+		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
 			"dev": true
 		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"dev": true
+		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-					"dev": true
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 				}
 			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"url": {
 			"version": "0.11.0",
@@ -8178,8 +9323,8 @@
 			"integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.0.2",
-				"mime": "1.3.x"
+				"loader-utils": "1.1.0",
+				"mime": "1.3.4"
 			}
 		},
 		"url-parse": {
@@ -8188,8 +9333,8 @@
 			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
 			"dev": true,
 			"requires": {
-				"querystringify": "~1.0.0",
-				"requires-port": "1.0.x"
+				"querystringify": "1.0.0",
+				"requires-port": "1.0.0"
 			},
 			"dependencies": {
 				"querystringify": {
@@ -8200,28 +9345,25 @@
 				}
 			}
 		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
 		"util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.1"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
-				}
+				"inherits": "2.0.3"
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"utils-merge": {
 			"version": "1.0.0",
@@ -8241,8 +9383,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "~1.0.0",
-				"spdx-expression-parse": "~1.0.0"
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
 			}
 		},
 		"vary": {
@@ -8263,9 +9405,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vm-browserify": {
@@ -8278,34 +9420,34 @@
 			}
 		},
 		"walt-compiler": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/walt-compiler/-/walt-compiler-0.16.2.tgz",
-			"integrity": "sha512-Req2G0vOqHp6Z2whXLFIGgU/JRU7CWWrtobDFp8WPhpiFFBwJWZFonCu5p7ZJxVhbiiHiXBDkKKRU8/V7I7/6g==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/walt-compiler/-/walt-compiler-0.17.0.tgz",
+			"integrity": "sha512-xzdjGu6BNbzRWfj2jH29FbNI+9clBXPLTyQWGl6fppT4DBky+5E1rTQzczvSXKLu0/uVszwktYwIwzOLjdGd0w==",
 			"requires": {
 				"curry": "1.2.0",
 				"invariant": "2.2.2",
-				"moo": "^0.4.3",
-				"nearley": "^2.15.1",
-				"walt-parser-tools": "^0.2.5",
-				"walt-syntax": "^0.4.1",
+				"moo": "0.4.3",
+				"nearley": "2.15.1",
+				"walt-parser-tools": "0.2.6",
+				"walt-syntax": "0.5.0",
 				"wasm-types": "1.0.3"
 			}
 		},
 		"walt-parser-tools": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/walt-parser-tools/-/walt-parser-tools-0.2.5.tgz",
-			"integrity": "sha512-C041eui2Z2L0jngUr4QFZcl5rmk0cRjbHOLE3/jQrh+jrkaZD5plxqjB1HGd2pVtsL7dNfGEcyOkOYugvTwGtA==",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/walt-parser-tools/-/walt-parser-tools-0.2.6.tgz",
+			"integrity": "sha512-u18sxkj7z7iXvgTl9XlnLstG8aTafZWbm41FlYm8RupeWwQvv9I1cFuq1sLMvlVH8jbzvadFVoMXwNZmK6WrTA==",
 			"requires": {
-				"xtend": "^4.0.1"
+				"xtend": "4.0.1"
 			}
 		},
 		"walt-plugin-syntax-closure": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/walt-plugin-syntax-closure/-/walt-plugin-syntax-closure-0.2.6.tgz",
-			"integrity": "sha512-ezfWQ+uUZNWIxFK5MnwBtPloxX+f3vdajPrclJX/dCMrWapfi8V0dxjIvFE+jvu31MohePMLc74x/1UYq8WCCQ==",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/walt-plugin-syntax-closure/-/walt-plugin-syntax-closure-0.2.8.tgz",
+			"integrity": "sha512-vOoWnPNcqTMPykJ+HBY168xp/L1QS7WoC+XuVZ7Z/UXnXhg4KuALySm5oDjjNZVlgbjUkC3zi0Cqc+Svpne+bg==",
 			"requires": {
-				"walt-parser-tools": "^0.2.5",
-				"walt-syntax": "^0.1.1"
+				"walt-parser-tools": "0.2.6",
+				"walt-syntax": "0.1.2"
 			},
 			"dependencies": {
 				"walt-syntax": {
@@ -8316,9 +9458,9 @@
 			}
 		},
 		"walt-syntax": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/walt-syntax/-/walt-syntax-0.4.1.tgz",
-			"integrity": "sha512-4ZvB6uQSgmGMgZLcYYQv0J/Au+EVNy31Jm+YT8rJWkA/rAeQNNMtirA6TtYnAkwAbuin3/LlPX7G7RvwagO/Sg=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/walt-syntax/-/walt-syntax-0.5.0.tgz",
+			"integrity": "sha512-T8hqmwfTlnq/z3KdBBWLEQBdhFQDhv5m01J/0DKcpE7nXvFR/YP/HSdWihp0tiQRJM2KpFbZROWDnT+/e5iWbQ=="
 		},
 		"wasm-types": {
 			"version": "1.0.3",
@@ -8326,14 +9468,887 @@
 			"integrity": "sha512-NjakjxCbrC0m4uNENhiFzEmj64DBw9EWxDs8SvS/TYxZqrwVLKBN3U8B8FPVDqOH2HMsBHu27G2i3gFMBkqSRg=="
 		},
 		"watchpack": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.2",
-				"chokidar": "^1.7.0",
-				"graceful-fs": "^4.1.2"
+				"chokidar": "2.0.4",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.6.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "3.1.10",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"chokidar": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+					"dev": true,
+					"requires": {
+						"anymatch": "2.0.0",
+						"async-each": "1.0.1",
+						"braces": "2.3.2",
+						"fsevents": "1.2.4",
+						"glob-parent": "3.1.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "4.0.0",
+						"lodash.debounce": "4.0.8",
+						"normalize-path": "2.1.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0",
+						"upath": "1.1.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.8",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fsevents": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "2.11.1",
+						"node-pre-gyp": "0.10.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"balanced-match": "1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "1.0.0",
+								"inflight": "1.0.6",
+								"inherits": "2.0.3",
+								"minimatch": "3.0.4",
+								"once": "1.4.0",
+								"path-is-absolute": "1.0.1"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "2.1.2"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "1.4.0",
+								"wrappy": "1.0.2"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"brace-expansion": "1.1.11"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "2.6.9",
+								"iconv-lite": "0.4.21",
+								"sax": "1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "1.0.3",
+								"mkdirp": "0.5.1",
+								"needle": "2.2.0",
+								"nopt": "4.0.1",
+								"npm-packlist": "1.1.10",
+								"npmlog": "4.1.2",
+								"rc": "1.2.7",
+								"rimraf": "2.6.2",
+								"semver": "5.5.0",
+								"tar": "4.4.1"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1.1.1",
+								"osenv": "0.1.5"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "3.0.1",
+								"npm-bundled": "1.0.3"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "1.1.4",
+								"console-control-strings": "1.1.0",
+								"gauge": "2.7.4",
+								"set-blocking": "2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"wrappy": "1.0.2"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "1.0.2",
+								"os-tmpdir": "1.0.2"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "0.5.1",
+								"ini": "1.3.5",
+								"minimist": "1.2.0",
+								"strip-json-comments": "2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.3",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.1",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "7.1.2"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "2.1.1"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "1.0.1",
+								"fs-minipass": "1.2.5",
+								"minipass": "2.2.4",
+								"minizlib": "1.1.0",
+								"mkdirp": "0.5.1",
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
+					"requires": {
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"dev": true,
+							"requires": {
+								"is-extglob": "2.1.1"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
+				"nan": {
+					"version": "2.11.1",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+					"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"wbuf": {
@@ -8342,7 +10357,7 @@
 			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
 			"dev": true,
 			"requires": {
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"webpack": {
@@ -8351,42 +10366,30 @@
 			"integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^5.1.5",
-				"ajv-keywords": "^2.0.0",
-				"async": "^2.1.2",
-				"enhanced-resolve": "^3.4.0",
-				"escope": "^3.6.0",
-				"interpret": "^1.0.0",
-				"json-loader": "^0.5.4",
-				"json5": "^0.5.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"mkdirp": "~0.5.0",
-				"node-libs-browser": "^2.0.0",
-				"source-map": "^0.5.3",
-				"supports-color": "^4.2.1",
-				"tapable": "^0.2.7",
-				"uglifyjs-webpack-plugin": "^0.4.6",
-				"watchpack": "^1.4.0",
-				"webpack-sources": "^1.0.1",
-				"yargs": "^8.0.2"
+				"acorn": "5.1.2",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"async": "2.5.0",
+				"enhanced-resolve": "3.4.1",
+				"escope": "3.6.0",
+				"interpret": "1.1.0",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.1",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.1.0",
+				"source-map": "0.5.7",
+				"supports-color": "4.5.0",
+				"tapable": "0.2.8",
+				"uglifyjs-webpack-plugin": "0.4.6",
+				"watchpack": "1.6.0",
+				"webpack-sources": "1.3.0",
+				"yargs": "8.0.2"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -8397,12 +10400,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"fast-json-stable-stringify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 					"dev": true
 				},
 				"has-flag": {
@@ -8423,10 +10420,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"os-locale": {
@@ -8435,9 +10432,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"path-type": {
@@ -8446,7 +10443,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"read-pkg": {
@@ -8455,9 +10452,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -8466,8 +10463,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"string-width": {
@@ -8476,8 +10473,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -8486,7 +10483,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -8501,7 +10498,60 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "1.2.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+							"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+							"dev": true
+						},
+						"cliui": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+							"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+							"dev": true,
+							"requires": {
+								"center-align": "0.1.3",
+								"right-align": "0.1.3",
+								"wordwrap": "0.0.2"
+							}
+						},
+						"yargs": {
+							"version": "3.10.0",
+							"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+							"dev": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglifyjs-webpack-plugin": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-js": "2.8.29",
+						"webpack-sources": "1.3.0"
 					}
 				},
 				"which-module": {
@@ -8516,19 +10566,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -8537,7 +10587,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -8548,11 +10598,11 @@
 			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
 			"dev": true,
 			"requires": {
-				"memory-fs": "~0.4.1",
-				"mime": "^1.3.4",
-				"path-is-absolute": "^1.0.0",
-				"range-parser": "^1.0.3",
-				"time-stamp": "^2.0.0"
+				"memory-fs": "0.4.1",
+				"mime": "1.3.4",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
 			}
 		},
 		"webpack-dev-server": {
@@ -8562,29 +10612,29 @@
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
-				"array-includes": "^3.0.3",
-				"bonjour": "^3.5.0",
-				"chokidar": "^1.6.0",
-				"compression": "^1.5.2",
-				"connect-history-api-fallback": "^1.3.0",
-				"del": "^3.0.0",
-				"express": "^4.13.3",
-				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.17.4",
-				"internal-ip": "^2.0.2",
-				"ip": "^1.1.5",
-				"loglevel": "^1.4.1",
-				"opn": "^5.1.0",
-				"portfinder": "^1.0.9",
-				"selfsigned": "^1.9.1",
-				"serve-index": "^1.7.2",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "1.7.0",
+				"compression": "1.7.0",
+				"connect-history-api-fallback": "1.3.0",
+				"del": "3.0.0",
+				"express": "4.15.4",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"internal-ip": "2.0.3",
+				"ip": "1.1.5",
+				"loglevel": "1.5.0",
+				"opn": "5.1.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.1",
+				"serve-index": "1.9.0",
 				"sockjs": "0.3.18",
 				"sockjs-client": "1.1.4",
-				"spdy": "^3.4.1",
-				"strip-ansi": "^3.0.1",
-				"supports-color": "^4.2.1",
-				"webpack-dev-middleware": "^1.11.0",
-				"yargs": "^6.6.0"
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "4.5.0",
+				"webpack-dev-middleware": "1.12.0",
+				"yargs": "6.6.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -8605,7 +10655,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				},
 				"yargs": {
@@ -8614,19 +10664,19 @@
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
 					}
 				},
 				"yargs-parser": {
@@ -8635,19 +10685,25 @@
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "3.0.0"
 					}
 				}
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
-			"dev": true,
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.5.3"
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"websocket-driver": {
@@ -8656,8 +10712,8 @@
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 			"dev": true,
 			"requires": {
-				"http-parser-js": ">=0.4.0",
-				"websocket-extensions": ">=0.1.1"
+				"http-parser-js": "0.4.6",
+				"websocket-extensions": "0.1.2"
 			}
 		},
 		"websocket-extensions": {
@@ -8681,9 +10737,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -8698,7 +10753,7 @@
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.2 || 2"
+				"string-width": "1.0.2"
 			}
 		},
 		"window-size": {
@@ -8713,21 +10768,43 @@
 			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
 			"dev": true
 		},
+		"worker-farm": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"requires": {
+				"errno": "0.1.7"
+			},
+			"dependencies": {
+				"errno": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+					"requires": {
+						"prr": "1.0.1"
+					}
+				},
+				"prr": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				}
+			}
+		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
@@ -8735,7 +10812,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"xtend": {
@@ -8752,8 +10829,7 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "7.1.0",
@@ -8761,19 +10837,19 @@
 			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^3.0.0",
-				"cliui": "^3.2.0",
-				"decamelize": "^1.1.1",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^1.4.0",
-				"read-pkg-up": "^1.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^1.0.2",
-				"which-module": "^1.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^5.0.0"
+				"camelcase": "3.0.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "1.4.0",
+				"read-pkg-up": "1.0.1",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "1.0.2",
+				"which-module": "1.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "5.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -8790,7 +10866,7 @@
 			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^3.0.0"
+				"camelcase": "3.0.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/packages/walt-docs/package.json
+++ b/packages/walt-docs/package.json
@@ -7,6 +7,7 @@
     "start": "webpack-dev-server -d --hot --inline",
     "start-container": "webpack-dev-server -d --hot --inline --host=$(hostname -I | xargs)",
     "build": "webpack && cp index.html explorer.js explorer.js.map walt.png ../../docs/",
+    "build:prod": "cross-env NODE_ENV=production webpack && cp index.html explorer.js explorer.js.map walt.png ../../docs/",
     "prettier": "prettier",
     "preversion": "npm run build"
   },
@@ -57,11 +58,12 @@
     "sass-loader": "6.0.6",
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",
-    "webpack": "3.6.0",
+    "webpack": "^3.6.0",
     "webpack-dev-server": "2.8.2"
   },
   "dependencies": {
     "codemirror": "5.29.0",
+    "cross-env": "^5.2.0",
     "prop-types": "15.5.10",
     "ramda": "0.25.0",
     "react": "15.6.1",
@@ -69,6 +71,7 @@
     "react-dom": "15.6.1",
     "semantic-ui-css": "2.2.12",
     "semantic-ui-react": "0.73.1",
+    "uglifyjs-webpack-plugin": "^1.3.0",
     "walt-compiler": "^0.17.0",
     "walt-plugin-syntax-closure": "^0.2.8"
   }

--- a/packages/walt-docs/webpack.config.js
+++ b/packages/walt-docs/webpack.config.js
@@ -1,4 +1,7 @@
 const path = require("path");
+const webpack=require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+
 
 module.exports = {
   context: __dirname + "/src",
@@ -16,6 +19,9 @@ module.exports = {
   resolve: {
     extensions: [".js", ".jsx", ".json", ".scss", ".css", ".walt"]
   },
+
+  plugins: [
+  ],
 
   module: {
     loaders: [
@@ -48,3 +54,21 @@ module.exports = {
     ]
   }
 };
+
+if (process.env.NODE_ENV === "production") {
+  module.exports.plugins.push(
+
+    new UglifyJsPlugin({
+      sourceMap: true,
+      cache: true,
+      parallel: true,
+    }),
+
+    new webpack.DefinePlugin({
+      "process.env": {
+        NODE_ENV: JSON.stringify('production'),
+      }
+    }),
+
+  );
+}


### PR DESCRIPTION
This submission supports "Production" build mode, in addition to, existing "Development" build. It essentially addresses the requirement of the following story to some extent:

https://github.com/ballercat/walt/issues/128

To execute production build, "build:prod" mode has been added to package.json  (in ~/packages/walt-docs/)
It reduces output JS file, explorer.js, by about 50%
Following testings have been performed for this submission:
- manually loading explorer.js file from /docs folder
- npm test