### PR TITLE
"null" as a value, struct bugfixes

### DIFF
--- a/packages/walt-compiler/src/__tests__/compiler-spec.js
+++ b/packages/walt-compiler/src/__tests__/compiler-spec.js
@@ -139,3 +139,25 @@ test('ternary', t => {
     t.is(instance.exports.run(0), -10);
   });
 });
+
+test('correct struct types parsed', t => {
+  const source = `
+  const memory : Memory = { initial: 1 };
+  type Node = {
+    data: i32,
+    left: Node,
+    right: Node
+  };
+  export function run() {
+    let node : Node = 0;
+
+    if (node.left != null) {
+      node = node.left;
+    } else if (node.left != null) {
+      node = node.right;
+    }
+  }
+  `;
+
+  return compileAndRun(source, {}, { debug: false }).then(({ instance }) => {});
+});

--- a/packages/walt-compiler/src/__tests__/compiler-spec.js
+++ b/packages/walt-compiler/src/__tests__/compiler-spec.js
@@ -140,7 +140,7 @@ test('ternary', t => {
   });
 });
 
-test('correct struct types parsed', t => {
+test('struct types in binary expr with nulls', () => {
   const source = `
   const memory : Memory = { initial: 1 };
   type Node = {
@@ -159,5 +159,5 @@ test('correct struct types parsed', t => {
   }
   `;
 
-  return compileAndRun(source, {}, { debug: false }).then(({ instance }) => {});
+  return compileAndRun(source, {}, { debug: false });
 });

--- a/packages/walt-compiler/src/__tests__/object-literal-spec.js
+++ b/packages/walt-compiler/src/__tests__/object-literal-spec.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { getIR } from '..';
+import { compile } from '..';
 
 test('objects', t => {
   const walt = `
@@ -54,9 +54,9 @@ test('objects', t => {
   }
 `;
 
-  const wasm = getIR(walt);
+  const buffer = compile(walt, { encodeNames: true }).buffer();
 
-  return WebAssembly.instantiate(wasm.buffer()).then(result => {
+  return WebAssembly.instantiate(buffer).then(result => {
     const exports = result.instance.exports;
 
     t.is(exports.testSubscript(), 4, 'Regular old string subscripts');

--- a/packages/walt-compiler/src/core/index.js
+++ b/packages/walt-compiler/src/core/index.js
@@ -126,6 +126,16 @@ export default function Core(): SemanticPlugin {
             };
           }
 
+          // null-expr
+          if (node.value === 'null') {
+            return {
+              ...node,
+              value: '0',
+              type: 'i32',
+              Type: Syntax.Constant,
+            };
+          }
+
           return next(args);
         },
         [Syntax.MemoryAssignment]: _ignore => (args, transform) => {

--- a/packages/walt-compiler/src/generator/access.js
+++ b/packages/walt-compiler/src/generator/access.js
@@ -12,7 +12,7 @@ const generateAccess: GeneratorType = (node, parent) => {
   block.push({ kind: opcode.i32Add, params: [] });
 
   block.push({
-    kind: opcode[String(field.type) + 'Load'],
+    kind: opcode[String(node.type) + 'Load'],
     params: [
       // Alignment
       2,

--- a/packages/walt-compiler/src/generator/access.js
+++ b/packages/walt-compiler/src/generator/access.js
@@ -5,19 +5,21 @@ import type { GeneratorType } from './flow/types';
 import mapSyntax from './map-syntax';
 
 const generateAccess: GeneratorType = (node, parent) => {
+  const [, field] = node.params;
   const block = node.params.map(mapSyntax(parent)).reduce(mergeBlock, []);
   // The sequence of opcodes to perfrom a memory load is
   // get(Local|Global) base, i32Const offset[, i32Const size, i32Mul ], i32Add
   block.push({ kind: opcode.i32Add, params: [] });
 
   block.push({
-    kind: opcode[String(node.type) + 'Load'],
+    kind: opcode[String(field.type) + 'Load'],
     params: [
       // Alignment
       2,
       // Memory. Always 0 in the WASM MVP
       0,
     ],
+    debug: `access ${node.value} of type ${String(field.type)}`,
   });
 
   return block;

--- a/packages/walt-compiler/src/index.js
+++ b/packages/walt-compiler/src/index.js
@@ -30,7 +30,7 @@ export {
   walkNode,
   mapNode,
 };
-export const VERSION = '0.19.0';
+export const VERSION = '0.20.0';
 
 // Used for debugging purposes
 export const getIR = (source: string, config: ConfigType) => {


### PR DESCRIPTION
- Makes sure structs within structs are handled correctly (like a linked list type for example) during access. So that accessed fields always have the correct type.
- Add's support for `null`